### PR TITLE
Deprecate extensions/v1beta1 ingress type in v1.21+

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,21 @@ charts:
   values: values.yaml
 ```
 
+# IMPORTANT VERSION INFORMATION
+
+Kubernetes has deprecated the API for `ingress` type as of v1.19 and removed the [deprecated version](https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/#what-to-do) as of v1.22.
+We have introduced this breaking change internally for all customers who upgrade to v1.21. This means that you should use the v1.20 tag for cluster versions up to v1.20 and use the main branch or later releases
+for versions v1.21 and above. The reason for this change is that customers who use v1.20 of the chart will be able to upgrade to v1.21 of Kubernetes without breaking any existing ingress charts. Once upgraded,
+the v1.21 chart will need to be used for any new ingress templates. This gives customers a smooth upgrade path without breaking exisitng infrastructure and applications. When v1.22 and above are available,
+customers will be able to use only the new chart version.
+
+The example for using v1.20 is similar to the above:
+```yaml
+charts:
+  repo_url: https://github.com/releasehub-com/helm-ingress.git#v1.20
+```
+
+# Values File Example
 To use the Helm chart you will need to have a `values.yaml` file located in your source control repository. You will need to customize the `values.yaml` file to reference the service that you would like to expose to the Internet.
 
 ```yaml

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- $serviceName := .Values.service.name -}}
 {{- $servicePort := .Values.service.externalPort -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ ternary "extensions/v1beta1" "networking.k8s.io/v1" lt .Capabilities.KubeVersion.Minor 21 }}
 kind: Ingress
 metadata:
   name: {{ template "fullname" . }}
@@ -12,9 +12,10 @@ metadata:
   annotations:
     {{- range $key, $value := .Values.ingress.annotations }}
       {{ $key }}: {{ $value | quote }}
-    {{- end }}
+    {{- end /* annotations */}}
 spec:
   rules:
+  {{- if lt .Capabilities.KubeVersion.Minor 21 -}}
     {{- range $host := .Values.ingress.hosts }}
     - host: {{ $host }}
       http:
@@ -23,8 +24,22 @@ spec:
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
-    {{- end -}}
+    {{- end /* range */ -}}
+  {{- else /* Capabilities */ -}}
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ $serviceName }}
+              port:
+                number: {{ $servicePort }}
+    {{- end /* range */ -}}
+  {{- end /* Capabilities */ -}}
   {{- if .Values.ingress.tls }}
   tls:
 {{ toYaml .Values.ingress.tls | indent 4 }}
-  {{- end -}}
+  {{- end /* tls */ -}}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- $serviceName := .Values.service.name -}}
 {{- $servicePort := .Values.service.externalPort -}}
-apiVersion: {{ ternary "extensions/v1beta1" "networking.k8s.io/v1" lt .Capabilities.KubeVersion.Minor 21 }}
+apiVersion: {{ lt (atoi .Capabilities.KubeVersion.Minor) 21 | ternary "extensions/v1beta1" "networking.k8s.io/v1" }}
 kind: Ingress
 metadata:
   name: {{ template "fullname" . }}
@@ -12,10 +12,10 @@ metadata:
   annotations:
     {{- range $key, $value := .Values.ingress.annotations }}
       {{ $key }}: {{ $value | quote }}
-    {{- end /* annotations */}}
+    {{- end }}
 spec:
   rules:
-  {{- if lt .Capabilities.KubeVersion.Minor 21 -}}
+  {{- if lt (atoi .Capabilities.KubeVersion.Minor) 21 -}}
     {{- range $host := .Values.ingress.hosts }}
     - host: {{ $host }}
       http:
@@ -24,8 +24,8 @@ spec:
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
-    {{- end /* range */ -}}
-  {{- else /* Capabilities */ -}}
+    {{- end -}}
+  {{- else -}}
     {{- range $host := .Values.ingress.hosts }}
     - host: {{ $host }}
       http:
@@ -37,9 +37,9 @@ spec:
                 name: {{ $serviceName }}
               port:
                 number: {{ $servicePort }}
-    {{- end /* range */ -}}
-  {{- end /* Capabilities */ -}}
+    {{- end -}}
+  {{- end -}}
   {{- if .Values.ingress.tls }}
   tls:
 {{ toYaml .Values.ingress.tls | indent 4 }}
-  {{- end /* tls */ -}}
+  {{- end -}}


### PR DESCRIPTION
This will allow customers to use the new API in clusters with v1.21+ We introduce the breaking changes one version before they become deprecated in v1.22 so that we can run both without breaking an existing cluster during a version upgrade.